### PR TITLE
Determine data is JSON by parsing, not headers

### DIFF
--- a/discord_rest.lua
+++ b/discord_rest.lua
@@ -88,10 +88,12 @@ end
 function createSimplePromiseCallback(p)
 	return function(status, data, headers)
 		if isResponseSuccess(status) then
-			if headers["Content-Type"] == "application/json" then
-				p:resolve(json.decode(data))
+			object = json.decode(data)
+
+			if object == nil then
+				p:reject(data)
 			else
-				p:resolve(status)
+				p:resolve(object)
 			end
 		else
 			p:reject(status)


### PR DESCRIPTION
Reading the response headers from PerformHttpRequest is made difficult by the lack of standardization in the capitalization. Instead of relying on them to determine if the Discord API returned back JSON data, just try parsing instead, since json.decode will simply return `nil` in case of invalid JSON input.